### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build robot code
+permissions:
+  contents: read
 on: pull_request
 jobs:
   gradle:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration for building the robot code. The change sets explicit permissions for the workflow, specifying that it only requires read access to repository contents.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R2-R3): Added `permissions` block with `contents: read` to restrict workflow permissions.